### PR TITLE
Updated linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-## Add the Meshtastic Debian Repository
+## Add the Meshtastic Linux Repository
 
-Download the [public key](meshtastic-deb.gpg) and put it in
-`/etc/apt/keyrings/meshtastic-deb.gpg`. You can achieve this with:
-
-```bash
-wget -qO- {{ site.url }}/meshtastic-deb.asc | sudo tee /etc/apt/keyrings/meshtastic-deb.asc >/dev/null
-```
-
-Next, create the source in `/etc/apt/sources.list.d/`
-
-```bash
-echo "deb [arch=all signed-by=/etc/apt/keyrings/meshtastic-deb.asc] {{ site.url }}/deb stable main" | sudo tee /etc/apt/sources.list.d/meshtastic-deb.list >/dev/null
-```
-
-If you want to have the latest version of the software, you can replace `stable` with `unstable`.
-
-Then run `sudo apt update && sudo apt install -y meshtasticd`.
+In the official documentation, you can find [Installation Instructions](https://meshtastic.org/docs/software/linux/installation/) for Debian, Raspbian, Ubuntu, Fedora and Docker.


### PR DESCRIPTION
Updated to point users who visit https://meshtastic.github.io/ to the correct installation instructions.